### PR TITLE
Add and populate Automatic updates column, add and handle enable/disable auto-updates bulk actions to the multisite themes list table.

### DIFF
--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -562,6 +562,7 @@ function wp_autoupdates_notices() {
 	}
 }
 add_action( 'admin_notices', 'wp_autoupdates_notices' );
+add_action( 'network_admin_notices', 'wp_autoupdates_notices' );
 
 /**
  * Add views for auto-update enabled/disabled.
@@ -1214,10 +1215,10 @@ function wp_autoupdates_themes_bulk_actions_handle( $redirect_to, $doaction, $it
 		update_site_option( 'wp_auto_update_themes', $new_autoupdated_themes );
 
 		if ( 'themes.php' === $pagenow ) {
-			$redirect_to = self_admin_url( "themes.php?enable-autoupdate=true&theme_status=$status&paged=$page&s=$s" );
+			$redirect_to = self_admin_url( "themes.php?disable-autoupdate=true&theme_status=$status&paged=$page&s=$s" );
 		}
 		else {
-			$redirect_to = self_admin_url( "site-themes.php?id=$id&enable-autoupdate=true&theme_status=$status&paged=$page&s=$s" );
+			$redirect_to = self_admin_url( "site-themes.php?id=$id&disable-autoupdate=true&theme_status=$status&paged=$page&s=$s" );
 		}
 		return $redirect_to;
 	}

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -1223,3 +1223,4 @@ function wp_autoupdates_themes_bulk_actions_handle( $redirect_to, $doaction, $it
 	}
 }
 add_action( 'handle_network_bulk_actions-themes-network', 'wp_autoupdates_themes_bulk_actions_handle', 10, 3 );
+add_action( 'handle_network_bulk_actions-site-themes-network', 'wp_autoupdates_themes_bulk_actions_handle', 10, 3 );

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -1093,7 +1093,7 @@ add_action( 'manage_themes_custom_column' , 'wp_autoupdates_add_themes_autoupdat
 
 
 /**
- * Add plugins autoupdates bulk actions
+ * Add themes autoupdates bulk actions
  */
 function wp_autoupdates_themes_bulk_actions( $actions ) {
 	$actions['enable-autoupdate-selected']  = __( 'Enable auto-updates', 'wp-autoupdates' );


### PR DESCRIPTION
Fixes #15.

A few notes:

0. I put this together by copy-paste-modify the equivalent functions for plugins.  Please double check that I correctly replaced **all** occurrences of `plugin` with `theme` (including in comments, etc).
1. While the hooks exist to add the `Auto-update enabled/disabled` views to the list table, there is not core hook equivalent to the one we use for the plugins list table to actually restrict the themes shown in the list according to those views.  Therefore, this PR does **not** added those views
   * adding those views when this plugin is merged into core will be no problem
   * we should call this out in the changelog when 0.4.0 is released
2. I realized when putting this together that we are **not** currently displaying admin notices when bulk actions are applied for plugins.  Therefore, I didn't do them for this PR either.  I'll open an issue (and do a separate PR) for that.
3. I just realized (while typing this) that I forgot to cover the case of the list table in `Network > Sites > Edit > Themes`.  I'll update this PR to cover that shortly.