### PR TITLE
Remove green and red colors on texts and links

### DIFF
--- a/css/wp-autoupdates.css
+++ b/css/wp-autoupdates.css
@@ -2,22 +2,6 @@
 	min-width: 200px;
 }
 
-.autoupdates_column .plugin-autoupdate-enabled,
-.theme-overlay .theme-autoupdate-enabled a {
-	color: #006505;
-}
-
-.autoupdates_column .plugin-autoupdate-disable,
-.autoupdates_column .theme-autoupdate-disable,
-.theme-overlay .theme-autoupdate-disabled a {
-	color: #a00;
-}
-
-.plugin-autoupdate-enabled,
-.theme-autoupdate-enabled {
-	color: #006505;
-}
-
 .plugins .plugin-title .plugin-autoupdate-enabled .dashicons,
 #update-themes-table .plugin-title .dashicons {
 	float: none;
@@ -31,7 +15,6 @@
 	background: transparent;
 	box-shadow: none;
 	font-size: 20px;
-	color: #006505;
 }
 
 .theme-overlay .theme-autoupdate a {


### PR DESCRIPTION
As seen in issues #56, #40 and during today's _core-auto-updates_ meeting:

- Replace red links with classic blue links are auto-update disabling is not a "destructive" action.
- Replace green text with black text as it doesn't provide any useful information. It may even confuse website administrators.

Fixes #56, fixes #40