### PR TITLE
Replace "Enable" string with "Enable auto-updates"

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -296,7 +296,7 @@ function wp_autoupdates_add_plugins_autoupdates_column_content( $column_name, $p
 					'<a href="%s" class="edit" aria-label="%s"><span class="dashicons dashicons-update" aria-hidden="true"></span> %s</a>',
 					wp_nonce_url( 'plugins.php?action=autoupdate&amp;plugin=' . urlencode( $plugin_file ) . '&amp;paged=' . $page . '&amp;plugin_status=' . $plugin_status, 'autoupdate-plugin_' . $plugin_file ),
 					$aria_label,
-					__( 'Enable', 'wp-autoupdates' )
+					__( 'Enable auto-updates', 'wp-autoupdates' )
 				);
 				echo '</p>';
 			}
@@ -840,7 +840,7 @@ function wp_autoupdates_debug_information( $info ) {
 				$theme_part = 'wp-active-theme';
 
 				if ( in_array( $theme_path, $wp_auto_update_themes ) ) {
-					$theme_auto_update_string       = sprintf( __( 'Enabled', 'wp-autoupdates' ) );
+					$theme_auto_update_string = sprintf( __( 'Enabled', 'wp-autoupdates' ) );
 				} else {
 					$theme_auto_update_string = sprintf( __( 'Disabled', 'wp-autoupdates' ) );
 				}
@@ -1240,7 +1240,7 @@ function wp_autoupdates_add_themes_autoupdates_column_content( $column_name, $st
 					'<a href="%s" class="edit" aria-label="%s"><span class="dashicons dashicons-update" aria-hidden="true"></span> %s</a>',
 					wp_nonce_url( $base_url, 'autoupdate-theme_' . $stylesheet ),
 					$aria_label,
-					__( 'Enable', 'wp-autoupdates' )
+					__( 'Enable auto-updates', 'wp-autoupdates' )
 				);
 				echo '</p>';
 			}


### PR DESCRIPTION
 As per today’s _#core-auto-updates_ team meeting, replace "Enable" string with "Enable auto-updates"for_ clearer interface, especially on small screens.

Fixes #72 