### PR TITLE
Add the plugin version when enqueueing styles, for cache busting.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -13,7 +13,7 @@ function wp_autoupdates_enqueues( $hook ) {
 	if ( ! in_array( $hook, array( 'plugins.php', 'themes.php', 'update-core.php' ) ) ) {
 		return;
 	}
-	wp_register_style( 'wp-autoupdates', plugin_dir_url( __FILE__ ) . 'css/wp-autoupdates.css', array() );
+	wp_register_style( 'wp-autoupdates', plugin_dir_url( __FILE__ ) . 'css/wp-autoupdates.css', array(), WP_AUTO_UPDATES_VERSION );
 	wp_enqueue_style( 'wp-autoupdates' );
 
 	// Update core screen JS hack (due to lack of filters).

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -21,6 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Invalid request.' );
 }
 
+define( 'WP_AUTO_UPDATES_VERSION', '0.5.0' );
 
 /**
  * Load only when needed.


### PR DESCRIPTION
Let's do a quick 0.5.1 release with this change.

Just remember to update the value if the `WP_AUTO_UPDATES_VERSION` when you do the release :-)