### PR TITLE
Accessibility: Communicate AJAX enabling/disabling changes to screen readers

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -117,7 +117,7 @@ function wp_autoupdates_enqueues( $hook ) {
 		wp_enqueue_script(
 			'wp-autoupdates',
 			plugin_dir_url( __FILE__ ) . 'js/wp-autoupdates.js',
-			array( 'jquery', 'wp-ajax-response' ),
+			array( 'jquery', 'wp-ajax-response', 'wp-a11y' ),
 			WP_AUTO_UPDATES_VERSION,
 			true
 		);
@@ -130,6 +130,7 @@ function wp_autoupdates_enqueues( $hook ) {
 				'disable'      => __( 'Disable auto-updates', 'wp-autoupdates' ),
 				'disabling'    => __( 'Disabling auto-updates...', 'wp-autoupdates' ),
 				'auto_enabled' => __( 'Auto-updates enabled', 'wp-autoupdates' ),
+				'auto_disabled' => __( 'Auto-updates disabled', 'wp-autoupdates' ),
 			)
 		);
 	}

--- a/js/wp-autoupdates.js
+++ b/js/wp-autoupdates.js
@@ -27,6 +27,7 @@ jQuery(function ($) {
 			$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
 			$parent.html( response.data.return_html );
 			$parent.find('.plugin-autoupdate-enable').focus();
+			wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
 		})
 		.fail(function (response) {
 			// todo - Better error handling.
@@ -63,6 +64,7 @@ jQuery(function ($) {
 			$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
 			$parent.html( response.data.return_html );
 			$parent.find('.plugin-autoupdate-disable').focus();
+			wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
 		})
 		.fail(function (response) {
 			// todo - Better error handling.
@@ -99,6 +101,7 @@ jQuery(function ($) {
 			$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
 			$parent.html( response.data.return_html );
 			$parent.find('.theme-autoupdate-enable').focus();
+			wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
 		})
 		.fail(function (response) {
 			// todo - Better error handling.
@@ -135,6 +138,7 @@ jQuery(function ($) {
 			$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
 			$parent.html( response.data.return_html );
 			$parent.find('.theme-autoupdate-disable').focus();
+			wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
 		})
 		.fail(function (response) {
 			// todo - Better error handling.
@@ -169,6 +173,7 @@ jQuery(function ($) {
 		.done(function (response) {
 			$parent.html( response.data.return_html );
 			$parent.find('.theme-autoupdate-enable').focus();
+			wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
 		})
 		.fail(function (response) {
 			// todo - Better error handling.
@@ -203,6 +208,7 @@ jQuery(function ($) {
 		.done(function (response) {
 			$parent.html( response.data.return_html );
 			$parent.find('.theme-autoupdate-disable').focus();
+			wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
 		})
 		.fail(function (response) {
 			// todo - Better error handling.


### PR DESCRIPTION
This PR usess `wp.a11y.speak` to communicate action links AJAX changes to screen reader users.
Fixes #84 

![7ecd6a68391c5c53fbfc8e2aeb92bb27](https://user-images.githubusercontent.com/1590998/79862413-59241b80-83d6-11ea-92e3-7a99b13f28ec.gif)
