### PR TITLE
Add Better Handling to Ajax Errors

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1359,7 +1359,7 @@ function wp_autoupdates_disable_auto_updates() {
 
 	// Capability check.
 	if ( 'plugin' === $type ) {
-		if ( true ||  ! current_user_can( 'update_plugins' ) ) {
+		if ( ! current_user_can( 'update_plugins' ) ) {
 			wp_send_json_error(
 				array(
 					'error' => __( 'You do not have permission to modify plugins.', 'wp-autoupdate' ),

--- a/functions.php
+++ b/functions.php
@@ -125,12 +125,13 @@ function wp_autoupdates_enqueues( $hook ) {
 			'wp-autoupdates',
 			'wp_autoupdates',
 			array(
-				'enable'       => __( 'Enable auto-updates', 'wp-autoupdates' ),
-				'enabling'     => __( 'Enabling auto-updates...', 'wp-autoupdates' ),
-				'disable'      => __( 'Disable auto-updates', 'wp-autoupdates' ),
-				'disabling'    => __( 'Disabling auto-updates...', 'wp-autoupdates' ),
-				'auto_enabled' => __( 'Auto-updates enabled', 'wp-autoupdates' ),
-				'auto_disabled' => __( 'Auto-updates disabled', 'wp-autoupdates' ),
+				'enable'            => __( 'Enable auto-updates', 'wp-autoupdates' ),
+				'enabling'          => __( 'Enabling auto-updates...', 'wp-autoupdates' ),
+				'disable'           => __( 'Disable auto-updates', 'wp-autoupdates' ),
+				'disabling'         => __( 'Disabling auto-updates...', 'wp-autoupdates' ),
+				'auto_enabled'      => __( 'Auto-updates enabled', 'wp-autoupdates' ),
+				'auto_disabled'     => __( 'Auto-updates disabled', 'wp-autoupdates' ),
+				'auto_update_error' => __( 'The request could not be completed', 'wp-autoupdates' ),
 			)
 		);
 	}
@@ -1358,7 +1359,7 @@ function wp_autoupdates_disable_auto_updates() {
 
 	// Capability check.
 	if ( 'plugin' === $type ) {
-		if ( ! current_user_can( 'update_plugins' ) ) {
+		if ( true ||  ! current_user_can( 'update_plugins' ) ) {
 			wp_send_json_error(
 				array(
 					'error' => __( 'You do not have permission to modify plugins.', 'wp-autoupdate' ),

--- a/js/wp-autoupdates.js
+++ b/js/wp-autoupdates.js
@@ -1,4 +1,9 @@
 jQuery(function ($) {
+
+	function add_error_notice( html, error ) {
+		html += '<div class="notice error"><p><strong>' + error + '</strong></p></div>';
+		return html;
+	}
 	// Disable auto-updates for a plugin.
 	$('.autoupdates_column').on('click', 'a.plugin-autoupdate-disable', function (e) {
 		e.preventDefault();
@@ -6,6 +11,9 @@ jQuery(function ($) {
 		$anchor.blur();
 		var href = wpAjax.unserialize($anchor.attr( 'href' ) );
 		var $parent = $anchor.parents( '.autoupdates_column' );
+		// Clear errors
+		$parent.find( '.notice' ).remove();
+		var html = $parent.html();
 
 		// Show loading status.
 		$anchor.html( '<span class="dashicons dashicons-update spin"></span> ' + wp_autoupdates.disabling );
@@ -23,15 +31,22 @@ jQuery(function ($) {
 			}
 		)
 		.done(function (response) {
-			$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
-			$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
-			$parent.html( response.data.return_html );
-			$parent.find('.plugin-autoupdate-enable').focus();
-			wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
+			if ( response.success ) {
+				$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
+				$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
+				$parent.html( response.data.return_html );
+				$parent.find('.plugin-autoupdate-enable').focus();
+				wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
+			} else {
+				var errorHTML = add_error_notice( html, response.data.error );
+				wp.a11y.speak( response.data.error, 'polite' );
+				$parent.html( errorHTML );
+			}
 		})
 		.fail(function (response) {
-			// todo - Better error handling.
-			alert( response.data.error );
+			var errorHTML = add_error_notice( html, wp_autoupdates.auto_update_error );
+			wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
+			$parent.html( errorHTML );
 		})
 		.always(function (response) {
 		});
@@ -43,6 +58,9 @@ jQuery(function ($) {
 		$anchor.blur();
 		var href = wpAjax.unserialize( $anchor.attr( 'href' ) );
 		var $parent = $anchor.parents( '.autoupdates_column' );
+		// Clear errors
+		$parent.find( '.notice' ).remove();
+		var html = $parent.html();
 
 		// Show loading status.
 		$anchor.addClass( 'spin' ).find( '.plugin-autoupdate-label' ).html( '<span class="dashicons dashicons-update spin"></span> ' + wp_autoupdates.enabling );
@@ -60,15 +78,22 @@ jQuery(function ($) {
 			}
 		)
 		.done(function (response) {
-			$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
-			$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
-			$parent.html( response.data.return_html );
-			$parent.find('.plugin-autoupdate-disable').focus();
-			wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
+			if ( response.success ) {
+				$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
+				$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
+				$parent.html( response.data.return_html );
+				$parent.find('.plugin-autoupdate-disable').focus();
+				wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
+			} else {
+				var errorHTML = add_error_notice( html, response.data.error );
+				wp.a11y.speak( response.data.error, 'polite' );
+				$parent.html( errorHTML );
+			}
 		})
 		.fail(function (response) {
-			// todo - Better error handling.
-			alert( response.data.error );
+			var errorHTML = add_error_notice( html, wp_autoupdates.auto_update_error );
+			wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
+			$parent.html( errorHTML );
 		})
 		.always(function (response) {
 		});
@@ -80,6 +105,9 @@ jQuery(function ($) {
 		$anchor.blur();
 		var href = wpAjax.unserialize($anchor.attr( 'href' ) );
 		var $parent = $anchor.parents( '.autoupdates_column' );
+		// Clear errors
+		$parent.find( '.notice' ).remove();
+		var html = $parent.html();
 
 		// Show loading status.
 		$anchor.html( '<span class="dashicons dashicons-update spin"></span> ' + wp_autoupdates.disabling );
@@ -97,15 +125,22 @@ jQuery(function ($) {
 			}
 		)
 		.done(function (response) {
-			$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
-			$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
-			$parent.html( response.data.return_html );
-			$parent.find('.theme-autoupdate-enable').focus();
-			wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
+			if ( response.success ) {
+				$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
+				$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
+				$parent.html( response.data.return_html );
+				$parent.find('.theme-autoupdate-enable').focus();
+				wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
+			} else {
+				var errorHTML = add_error_notice( html, response.data.error );
+				wp.a11y.speak( response.data.error, 'polite' );
+				$parent.html( errorHTML );
+			}
 		})
 		.fail(function (response) {
-			// todo - Better error handling.
-			alert( response.data.error );
+			var errorHTML = add_error_notice( html, wp_autoupdates.auto_update_error );
+			wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
+			$parent.html( errorHTML );
 		})
 		.always(function (response) {
 		});
@@ -117,6 +152,9 @@ jQuery(function ($) {
 		$anchor.blur();
 		var href = wpAjax.unserialize( $anchor.attr( 'href' ) );
 		var $parent = $anchor.parents( '.autoupdates_column' );
+		// Clear errors
+		$parent.find( '.notice' ).remove();
+		var html = $parent.html();
 
 		// Show loading status.
 		$anchor.addClass( 'spin' ).find( '.theme-autoupdate-label' ).html( '<span class="dashicons dashicons-update spin"></span> ' + wp_autoupdates.enabling );
@@ -134,15 +172,22 @@ jQuery(function ($) {
 			}
 		)
 		.done(function (response) {
-			$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
-			$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
-			$parent.html( response.data.return_html );
-			$parent.find('.theme-autoupdate-disable').focus();
-			wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
+			if ( response.success ) {
+				$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
+				$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
+				$parent.html( response.data.return_html );
+				$parent.find('.theme-autoupdate-disable').focus();
+				wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
+			} else {
+				var errorHTML = add_error_notice( html, response.data.error );
+				wp.a11y.speak( response.data.error, 'polite' );
+				$parent.html( errorHTML );
+			}
 		})
 		.fail(function (response) {
-			// todo - Better error handling.
-			alert( response.data.error );
+			var errorHTML = add_error_notice( html, wp_autoupdates.auto_update_error );
+			wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
+			$parent.html( errorHTML );
 		})
 		.always(function (response) {
 		});
@@ -154,6 +199,9 @@ jQuery(function ($) {
 		$anchor.blur();
 		var href = wpAjax.unserialize($anchor.attr( 'href' ) );
 		var $parent = $anchor.parents( '.theme-autoupdate' );
+		// Clear errors
+		$parent.find( '.notice' ).remove();
+		var html = $parent.html();
 
 		// Show loading status.
 		$anchor.html( '<span class="dashicons dashicons-update spin"></span> ' + wp_autoupdates.disabling );
@@ -171,13 +219,20 @@ jQuery(function ($) {
 			}
 		)
 		.done(function (response) {
-			$parent.html( response.data.return_html );
-			$parent.find('.theme-autoupdate-enable').focus();
-			wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
+			if ( response.success ) {
+				$parent.html( response.data.return_html );
+				$parent.find('.theme-autoupdate-enable').focus();
+				wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
+			} else {
+				var errorHTML = add_error_notice( html, response.data.error );
+				wp.a11y.speak( response.data.error, 'polite' );
+				$parent.html( errorHTML );
+			}
 		})
 		.fail(function (response) {
-			// todo - Better error handling.
-			alert( response.data.error );
+			var errorHTML = add_error_notice( html, wp_autoupdates.auto_update_error );
+			wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
+			$parent.html( errorHTML );
 		})
 		.always(function (response) {
 		});
@@ -189,6 +244,9 @@ jQuery(function ($) {
 		$anchor.blur();
 		var href = wpAjax.unserialize( $anchor.attr( 'href' ) );
 		var $parent = $anchor.parents( '.theme-autoupdate' );
+		// Clear errors
+		$parent.find( '.notice' ).remove();
+		var html = $parent.html();
 
 		// Show loading status.
 		$parent.find( '.theme-autoupdate-label' ).html( '<span class="dashicons dashicons-update spin"></span> ' + wp_autoupdates.enabling );
@@ -206,13 +264,21 @@ jQuery(function ($) {
 			}
 		)
 		.done(function (response) {
-			$parent.html( response.data.return_html );
-			$parent.find('.theme-autoupdate-disable').focus();
-			wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
+			if ( response.success ) {
+				$parent.html( response.data.return_html );
+				$parent.find('.theme-autoupdate-disable').focus();
+				wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
+			} else {
+				var errorHTML = add_error_notice( html, response.data.error );
+				wp.a11y.speak( response.data.error, 'polite' );
+				$parent.html( errorHTML );
+			}
+			
 		})
 		.fail(function (response) {
-			// todo - Better error handling.
-			alert( response.data.error );
+			var errorHTML = add_error_notice( html, wp_autoupdates.auto_update_error );
+			wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
+			$parent.html( errorHTML );
 		})
 		.always(function (response) {
 		});


### PR DESCRIPTION
Resolves #87 

This PR adds an inline error message when something fails, whether it's a capabilities check, or some other type of failure.

![ajax-error-handling-plugins](https://user-images.githubusercontent.com/636521/79979735-997faa00-8467-11ea-8e48-b286e824ef21.gif)

![themes-error-screen](https://user-images.githubusercontent.com/636521/79979744-9d133100-8467-11ea-9d7c-7d29092c176c.gif)
