### PR TITLE
Don't focus the enable/disable links after successful AJAX.

### DIFF
--- a/js/wp-autoupdates.js
+++ b/js/wp-autoupdates.js
@@ -35,7 +35,6 @@ jQuery(function ($) {
 				$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
 				$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
 				$parent.html( response.data.return_html );
-				$parent.find('.plugin-autoupdate-enable').focus();
 				wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
 			} else {
 				var errorHTML = add_error_notice( html, response.data.error );
@@ -82,7 +81,6 @@ jQuery(function ($) {
 				$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
 				$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
 				$parent.html( response.data.return_html );
-				$parent.find('.plugin-autoupdate-disable').focus();
 				wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
 			} else {
 				var errorHTML = add_error_notice( html, response.data.error );
@@ -129,7 +127,6 @@ jQuery(function ($) {
 				$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
 				$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
 				$parent.html( response.data.return_html );
-				$parent.find('.theme-autoupdate-enable').focus();
 				wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
 			} else {
 				var errorHTML = add_error_notice( html, response.data.error );
@@ -176,7 +173,6 @@ jQuery(function ($) {
 				$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
 				$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
 				$parent.html( response.data.return_html );
-				$parent.find('.theme-autoupdate-disable').focus();
 				wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
 			} else {
 				var errorHTML = add_error_notice( html, response.data.error );
@@ -221,7 +217,6 @@ jQuery(function ($) {
 		.done(function (response) {
 			if ( response.success ) {
 				$parent.html( response.data.return_html );
-				$parent.find('.theme-autoupdate-enable').focus();
 				wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
 			} else {
 				var errorHTML = add_error_notice( html, response.data.error );
@@ -266,7 +261,6 @@ jQuery(function ($) {
 		.done(function (response) {
 			if ( response.success ) {
 				$parent.html( response.data.return_html );
-				$parent.find('.theme-autoupdate-disable').focus();
 				wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
 			} else {
 				var errorHTML = add_error_notice( html, response.data.error );


### PR DESCRIPTION
Maybe it's just me, but I prefer to not have the enable/disable links focused after the AJAX succeeds.  I didn't notice this was happening until after I merged #90.

@ronalfy doing that seems to have been a conscious choice in your PR.  If there is a reason for it, then I'm OK with it, but putting this out to see what others think.