### PR TITLE
JS Coding Standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/js/wp-autoupdates.js
+++ b/js/wp-autoupdates.js
@@ -1,116 +1,279 @@
-jQuery(function ($) {
-
+jQuery( function( $ ) {
 	function add_error_notice( html, error ) {
-		html += '<div class="notice error"><p><strong>' + error + '</strong></p></div>';
+		html +=
+			'<div class="notice error"><p><strong>' +
+			error +
+			'</strong></p></div>';
 		return html;
 	}
 	// Disable auto-updates for a plugin.
-	$('.autoupdates_column').on('click', 'a.plugin-autoupdate-disable', function (e) {
-		e.preventDefault();
-		var $anchor = $( this );
-		$anchor.blur();
-		var href = wpAjax.unserialize($anchor.attr( 'href' ) );
-		var $parent = $anchor.parents( '.autoupdates_column' );
-		// Clear errors
-		$parent.find( '.notice' ).remove();
-		var html = $parent.html();
+	$( '.autoupdates_column' ).on(
+		'click',
+		'a.plugin-autoupdate-disable',
+		function( e ) {
+			e.preventDefault();
+			var $anchor = $( this );
+			$anchor.blur();
+			var href = wpAjax.unserialize( $anchor.attr( 'href' ) );
+			var $parent = $anchor.parents( '.autoupdates_column' );
+			// Clear errors
+			$parent.find( '.notice' ).remove();
+			var html = $parent.html();
 
-		// Show loading status.
-		$anchor.html( '<span class="dashicons dashicons-update spin"></span> ' + wp_autoupdates.disabling );
+			// Show loading status.
+			$anchor.html(
+				'<span class="dashicons dashicons-update spin"></span> ' +
+					wp_autoupdates.disabling
+			);
 
-		$.post(
-			ajaxurl,
-			{
-				action: 'disable_auto_updates',
-				_ajax_nonce: href._wpnonce,
-				type: 'plugin',
-				asset: href.plugin
-			},
-			function (response) {
-
-			}
-		)
-		.done(function (response) {
-			if ( response.success ) {
-				$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
-				$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
-				$parent.html( response.data.return_html );
-				$parent.find('.plugin-autoupdate-enable').focus();
-				wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
-			} else {
-				var errorHTML = add_error_notice( html, response.data.error );
-				wp.a11y.speak( response.data.error, 'polite' );
-				$parent.html( errorHTML );
-			}
-		})
-		.fail(function (response) {
-			var errorHTML = add_error_notice( html, wp_autoupdates.auto_update_error );
-			wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
-			$parent.html( errorHTML );
-		})
-		.always(function (response) {
-		});
-	});
+			$.post(
+				ajaxurl,
+				{
+					action: 'disable_auto_updates',
+					_ajax_nonce: href._wpnonce,
+					type: 'plugin',
+					asset: href.plugin,
+				},
+				function( response ) {}
+			)
+				.done( function( response ) {
+					if ( response.success ) {
+						$( '.autoupdate_enabled span' ).html(
+							response.data.enabled_count
+						);
+						$( '.autoupdate_disabled span' ).html(
+							response.data.disabled_count
+						);
+						$parent.html( response.data.return_html );
+						$parent.find( '.plugin-autoupdate-enable' ).focus();
+						wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
+					} else {
+						var errorHTML = add_error_notice(
+							html,
+							response.data.error
+						);
+						wp.a11y.speak( response.data.error, 'polite' );
+						$parent.html( errorHTML );
+					}
+				} )
+				.fail( function( response ) {
+					var errorHTML = add_error_notice(
+						html,
+						wp_autoupdates.auto_update_error
+					);
+					wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
+					$parent.html( errorHTML );
+				} )
+				.always( function( response ) {} );
+		}
+	);
 	// Enable auto-updates for a plugin.
-	$('.autoupdates_column').on('click', 'a.plugin-autoupdate-enable', function (e) {
+	$( '.autoupdates_column' ).on(
+		'click',
+		'a.plugin-autoupdate-enable',
+		function( e ) {
+			e.preventDefault();
+			var $anchor = $( this );
+			$anchor.blur();
+			var href = wpAjax.unserialize( $anchor.attr( 'href' ) );
+			var $parent = $anchor.parents( '.autoupdates_column' );
+			// Clear errors
+			$parent.find( '.notice' ).remove();
+			var html = $parent.html();
+
+			// Show loading status.
+			$anchor
+				.addClass( 'spin' )
+				.find( '.plugin-autoupdate-label' )
+				.html(
+					'<span class="dashicons dashicons-update spin"></span> ' +
+						wp_autoupdates.enabling
+				);
+
+			$.post(
+				ajaxurl,
+				{
+					action: 'enable_auto_updates',
+					_ajax_nonce: href._wpnonce,
+					type: 'plugin',
+					asset: href.plugin,
+				},
+				function( response ) {}
+			)
+				.done( function( response ) {
+					if ( response.success ) {
+						$( '.autoupdate_enabled span' ).html(
+							response.data.enabled_count
+						);
+						$( '.autoupdate_disabled span' ).html(
+							response.data.disabled_count
+						);
+						$parent.html( response.data.return_html );
+						$parent.find( '.plugin-autoupdate-disable' ).focus();
+						wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
+					} else {
+						var errorHTML = add_error_notice(
+							html,
+							response.data.error
+						);
+						wp.a11y.speak( response.data.error, 'polite' );
+						$parent.html( errorHTML );
+					}
+				} )
+				.fail( function( response ) {
+					var errorHTML = add_error_notice(
+						html,
+						wp_autoupdates.auto_update_error
+					);
+					wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
+					$parent.html( errorHTML );
+				} )
+				.always( function( response ) {} );
+		}
+	);
+	// Disable auto-updates for a theme.
+	$( '.autoupdates_column' ).on(
+		'click',
+		'a.theme-autoupdate-disable',
+		function( e ) {
+			e.preventDefault();
+			var $anchor = $( this );
+			$anchor.blur();
+			var href = wpAjax.unserialize( $anchor.attr( 'href' ) );
+			var $parent = $anchor.parents( '.autoupdates_column' );
+			// Clear errors
+			$parent.find( '.notice' ).remove();
+			var html = $parent.html();
+
+			// Show loading status.
+			$anchor.html(
+				'<span class="dashicons dashicons-update spin"></span> ' +
+					wp_autoupdates.disabling
+			);
+
+			$.post(
+				ajaxurl,
+				{
+					action: 'disable_auto_updates',
+					_ajax_nonce: href._wpnonce,
+					type: 'theme',
+					asset: href.theme,
+				},
+				function( response ) {}
+			)
+				.done( function( response ) {
+					if ( response.success ) {
+						$( '.autoupdate_enabled span' ).html(
+							response.data.enabled_count
+						);
+						$( '.autoupdate_disabled span' ).html(
+							response.data.disabled_count
+						);
+						$parent.html( response.data.return_html );
+						$parent.find( '.theme-autoupdate-enable' ).focus();
+						wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
+					} else {
+						var errorHTML = add_error_notice(
+							html,
+							response.data.error
+						);
+						wp.a11y.speak( response.data.error, 'polite' );
+						$parent.html( errorHTML );
+					}
+				} )
+				.fail( function( response ) {
+					var errorHTML = add_error_notice(
+						html,
+						wp_autoupdates.auto_update_error
+					);
+					wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
+					$parent.html( errorHTML );
+				} )
+				.always( function( response ) {} );
+		}
+	);
+	// Enable auto-updates for a theme.
+	$( '.autoupdates_column' ).on(
+		'click',
+		'a.theme-autoupdate-enable',
+		function( e ) {
+			e.preventDefault();
+			var $anchor = $( this );
+			$anchor.blur();
+			var href = wpAjax.unserialize( $anchor.attr( 'href' ) );
+			var $parent = $anchor.parents( '.autoupdates_column' );
+			// Clear errors
+			$parent.find( '.notice' ).remove();
+			var html = $parent.html();
+
+			// Show loading status.
+			$anchor
+				.addClass( 'spin' )
+				.find( '.theme-autoupdate-label' )
+				.html(
+					'<span class="dashicons dashicons-update spin"></span> ' +
+						wp_autoupdates.enabling
+				);
+
+			$.post(
+				ajaxurl,
+				{
+					action: 'enable_auto_updates',
+					_ajax_nonce: href._wpnonce,
+					type: 'theme',
+					asset: href.theme,
+				},
+				function( response ) {}
+			)
+				.done( function( response ) {
+					if ( response.success ) {
+						$( '.autoupdate_enabled span' ).html(
+							response.data.enabled_count
+						);
+						$( '.autoupdate_disabled span' ).html(
+							response.data.disabled_count
+						);
+						$parent.html( response.data.return_html );
+						$parent.find( '.theme-autoupdate-disable' ).focus();
+						wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
+					} else {
+						var errorHTML = add_error_notice(
+							html,
+							response.data.error
+						);
+						wp.a11y.speak( response.data.error, 'polite' );
+						$parent.html( errorHTML );
+					}
+				} )
+				.fail( function( response ) {
+					var errorHTML = add_error_notice(
+						html,
+						wp_autoupdates.auto_update_error
+					);
+					wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
+					$parent.html( errorHTML );
+				} )
+				.always( function( response ) {} );
+		}
+	);
+	// Disable auto-updates for a theme.
+	$( '.theme-overlay' ).on( 'click', 'a.theme-autoupdate-disable', function(
+		e
+	) {
 		e.preventDefault();
 		var $anchor = $( this );
 		$anchor.blur();
 		var href = wpAjax.unserialize( $anchor.attr( 'href' ) );
-		var $parent = $anchor.parents( '.autoupdates_column' );
+		var $parent = $anchor.parents( '.theme-autoupdate' );
 		// Clear errors
 		$parent.find( '.notice' ).remove();
 		var html = $parent.html();
 
 		// Show loading status.
-		$anchor.addClass( 'spin' ).find( '.plugin-autoupdate-label' ).html( '<span class="dashicons dashicons-update spin"></span> ' + wp_autoupdates.enabling );
-
-		$.post(
-			ajaxurl,
-			{
-				action: 'enable_auto_updates',
-				_ajax_nonce: href._wpnonce,
-				type: 'plugin',
-				asset: href.plugin
-			},
-			function (response) {
-
-			}
-		)
-		.done(function (response) {
-			if ( response.success ) {
-				$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
-				$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
-				$parent.html( response.data.return_html );
-				$parent.find('.plugin-autoupdate-disable').focus();
-				wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
-			} else {
-				var errorHTML = add_error_notice( html, response.data.error );
-				wp.a11y.speak( response.data.error, 'polite' );
-				$parent.html( errorHTML );
-			}
-		})
-		.fail(function (response) {
-			var errorHTML = add_error_notice( html, wp_autoupdates.auto_update_error );
-			wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
-			$parent.html( errorHTML );
-		})
-		.always(function (response) {
-		});
-	});
-	// Disable auto-updates for a theme.
-	$('.autoupdates_column').on('click', 'a.theme-autoupdate-disable', function (e) {
-		e.preventDefault();
-		var $anchor = $( this );
-		$anchor.blur();
-		var href = wpAjax.unserialize($anchor.attr( 'href' ) );
-		var $parent = $anchor.parents( '.autoupdates_column' );
-		// Clear errors
-		$parent.find( '.notice' ).remove();
-		var html = $parent.html();
-
-		// Show loading status.
-		$anchor.html( '<span class="dashicons dashicons-update spin"></span> ' + wp_autoupdates.disabling );
+		$anchor.html(
+			'<span class="dashicons dashicons-update spin"></span> ' +
+				wp_autoupdates.disabling
+		);
 
 		$.post(
 			ajaxurl,
@@ -118,127 +281,38 @@ jQuery(function ($) {
 				action: 'disable_auto_updates',
 				_ajax_nonce: href._wpnonce,
 				type: 'theme',
-				asset: href.theme
+				asset: href.theme,
 			},
-			function (response) {
-
-			}
+			function( response ) {}
 		)
-		.done(function (response) {
-			if ( response.success ) {
-				$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
-				$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
-				$parent.html( response.data.return_html );
-				$parent.find('.theme-autoupdate-enable').focus();
-				wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
-			} else {
-				var errorHTML = add_error_notice( html, response.data.error );
-				wp.a11y.speak( response.data.error, 'polite' );
+			.done( function( response ) {
+				if ( response.success ) {
+					$parent.html( response.data.return_html );
+					$parent.find( '.theme-autoupdate-enable' ).focus();
+					wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
+				} else {
+					var errorHTML = add_error_notice(
+						html,
+						response.data.error
+					);
+					wp.a11y.speak( response.data.error, 'polite' );
+					$parent.html( errorHTML );
+				}
+			} )
+			.fail( function( response ) {
+				var errorHTML = add_error_notice(
+					html,
+					wp_autoupdates.auto_update_error
+				);
+				wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
 				$parent.html( errorHTML );
-			}
-		})
-		.fail(function (response) {
-			var errorHTML = add_error_notice( html, wp_autoupdates.auto_update_error );
-			wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
-			$parent.html( errorHTML );
-		})
-		.always(function (response) {
-		});
-	});
+			} )
+			.always( function( response ) {} );
+	} );
 	// Enable auto-updates for a theme.
-	$('.autoupdates_column').on('click', 'a.theme-autoupdate-enable', function (e) {
-		e.preventDefault();
-		var $anchor = $( this );
-		$anchor.blur();
-		var href = wpAjax.unserialize( $anchor.attr( 'href' ) );
-		var $parent = $anchor.parents( '.autoupdates_column' );
-		// Clear errors
-		$parent.find( '.notice' ).remove();
-		var html = $parent.html();
-
-		// Show loading status.
-		$anchor.addClass( 'spin' ).find( '.theme-autoupdate-label' ).html( '<span class="dashicons dashicons-update spin"></span> ' + wp_autoupdates.enabling );
-
-		$.post(
-			ajaxurl,
-			{
-				action: 'enable_auto_updates',
-				_ajax_nonce: href._wpnonce,
-				type: 'theme',
-				asset: href.theme
-			},
-			function (response) {
-
-			}
-		)
-		.done(function (response) {
-			if ( response.success ) {
-				$( '.autoupdate_enabled span' ).html( response.data.enabled_count );
-				$( '.autoupdate_disabled span' ).html( response.data.disabled_count );
-				$parent.html( response.data.return_html );
-				$parent.find('.theme-autoupdate-disable').focus();
-				wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
-			} else {
-				var errorHTML = add_error_notice( html, response.data.error );
-				wp.a11y.speak( response.data.error, 'polite' );
-				$parent.html( errorHTML );
-			}
-		})
-		.fail(function (response) {
-			var errorHTML = add_error_notice( html, wp_autoupdates.auto_update_error );
-			wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
-			$parent.html( errorHTML );
-		})
-		.always(function (response) {
-		});
-	});
-	// Disable auto-updates for a theme.
-	$('.theme-overlay').on('click', 'a.theme-autoupdate-disable', function (e) {
-		e.preventDefault();
-		var $anchor = $( this );
-		$anchor.blur();
-		var href = wpAjax.unserialize($anchor.attr( 'href' ) );
-		var $parent = $anchor.parents( '.theme-autoupdate' );
-		// Clear errors
-		$parent.find( '.notice' ).remove();
-		var html = $parent.html();
-
-		// Show loading status.
-		$anchor.html( '<span class="dashicons dashicons-update spin"></span> ' + wp_autoupdates.disabling );
-
-		$.post(
-			ajaxurl,
-			{
-				action: 'disable_auto_updates',
-				_ajax_nonce: href._wpnonce,
-				type: 'theme',
-				asset: href.theme
-			},
-			function (response) {
-
-			}
-		)
-		.done(function (response) {
-			if ( response.success ) {
-				$parent.html( response.data.return_html );
-				$parent.find('.theme-autoupdate-enable').focus();
-				wp.a11y.speak( wp_autoupdates.auto_disabled, 'polite' );
-			} else {
-				var errorHTML = add_error_notice( html, response.data.error );
-				wp.a11y.speak( response.data.error, 'polite' );
-				$parent.html( errorHTML );
-			}
-		})
-		.fail(function (response) {
-			var errorHTML = add_error_notice( html, wp_autoupdates.auto_update_error );
-			wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
-			$parent.html( errorHTML );
-		})
-		.always(function (response) {
-		});
-	});
-	// Enable auto-updates for a theme.
-	$('.theme-overlay').on('click', 'a.theme-autoupdate-enable', function (e) {
+	$( '.theme-overlay' ).on( 'click', 'a.theme-autoupdate-enable', function(
+		e
+	) {
 		e.preventDefault();
 		var $anchor = $( this );
 		$anchor.blur();
@@ -249,7 +323,12 @@ jQuery(function ($) {
 		var html = $parent.html();
 
 		// Show loading status.
-		$parent.find( '.theme-autoupdate-label' ).html( '<span class="dashicons dashicons-update spin"></span> ' + wp_autoupdates.enabling );
+		$parent
+			.find( '.theme-autoupdate-label' )
+			.html(
+				'<span class="dashicons dashicons-update spin"></span> ' +
+					wp_autoupdates.enabling
+			);
 
 		$.post(
 			ajaxurl,
@@ -257,30 +336,32 @@ jQuery(function ($) {
 				action: 'enable_auto_updates',
 				_ajax_nonce: href._wpnonce,
 				type: 'theme',
-				asset: href.theme
+				asset: href.theme,
 			},
-			function (response) {
-
-			}
+			function( response ) {}
 		)
-		.done(function (response) {
-			if ( response.success ) {
-				$parent.html( response.data.return_html );
-				$parent.find('.theme-autoupdate-disable').focus();
-				wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
-			} else {
-				var errorHTML = add_error_notice( html, response.data.error );
-				wp.a11y.speak( response.data.error, 'polite' );
+			.done( function( response ) {
+				if ( response.success ) {
+					$parent.html( response.data.return_html );
+					$parent.find( '.theme-autoupdate-disable' ).focus();
+					wp.a11y.speak( wp_autoupdates.auto_enabled, 'polite' );
+				} else {
+					var errorHTML = add_error_notice(
+						html,
+						response.data.error
+					);
+					wp.a11y.speak( response.data.error, 'polite' );
+					$parent.html( errorHTML );
+				}
+			} )
+			.fail( function( response ) {
+				var errorHTML = add_error_notice(
+					html,
+					wp_autoupdates.auto_update_error
+				);
+				wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
 				$parent.html( errorHTML );
-			}
-			
-		})
-		.fail(function (response) {
-			var errorHTML = add_error_notice( html, wp_autoupdates.auto_update_error );
-			wp.a11y.speak( wp_autoupdates.auto_update_error, 'polite' );
-			$parent.html( errorHTML );
-		})
-		.always(function (response) {
-		});
-	});
-});
+			} )
+			.always( function( response ) {} );
+	} );
+} );

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+	"name": "wp-autoupdates",
+	"version": "1.0.0",
+	"description": "![WordPress Auto-updates](https://jeanbaptisteaudras.com/images/wp-autoupdates-banner.png)",
+	"author": "The WordPress Contributors",
+	"license": "GPL-2.0-or-later",
+	"keywords": [
+		"wordpress"
+	],
+	"homepage": "https://github.com/WordPress/wp-autoupdates#readme",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/WordPress/wp-autoupdates.git"
+	},
+	"bugs": {
+		"url": "https://github.com/WordPress/wp-autoupdates/issues"
+	},
+	"main": "index.js",
+	"devDependencies": {
+		"@wordpress/scripts": "^9.0.0"
+	},
+	"scripts": {
+		"format:js": "wp-scripts format-js",
+		"lint:css": "wp-scripts lint-style",
+		"lint:js": "wp-scripts lint-js",
+		"lint:md:docs": "wp-scripts lint-md-docs",
+		"lint:pkg-json": "wp-scripts lint-pkg-json",
+		"test": "npm run lint:css && npm run lint:md:docs && npm run lint:js"
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -89,18 +89,24 @@ Work in progress.
 ## Changelog 🗓
 
 ### 0.6.0 🦋
+
 April 22, 2020
+
 - Add Ajax to Plugin and Themes Screen - [#61](https://github.com/WordPress/wp-autoupdates/pull/61)
 - Accessibility: Communicate AJAX enabling/disabling changes to screen readers - [#85](https://github.com/WordPress/wp-autoupdates/pull/85)
 - Add Better Handling to Ajax Errors - [#90](https://github.com/WordPress/wp-autoupdates/pull/90)
 - Prevent CSS from being enqueued on sub-site plugins & themes screens in multisite - [#91](https://github.com/WordPress/wp-autoupdates/pull/91)
 
 ### 0.5.1 🦒
+
 April 16, 2020
+
 - Add the plugin version when enqueueing styles, for cache busting - [#79](https://github.com/WordPress/wp-autoupdates/pull/79)
 
 ### 0.5.0 🦚
+
 April 15, 2020
+
 - Replace Disable strings with Disable auto-updates - [#78](https://github.com/WordPress/wp-autoupdates/pull/78)
 - Update confirmation message wording - [#77](https://github.com/WordPress/wp-autoupdates/pull/77)
 - Remove Automatic Updates column from the Network Admin > Sites > Edit > Themes screen - [#76](https://github.com/WordPress/wp-autoupdates/pull/76)
@@ -116,10 +122,13 @@ April 15, 2020
 - Wrong kick off year in readme.txt - [#42](https://github.com/WordPress/wp-autoupdates/pull/60)
 
 ### 0.4.1 🍺
+
 April 2, 2020
+
 - Network > Sites > Edit > Themes screen doesn’t have the Autoupdates column - [#50](https://github.com/WordPress/wp-autoupdates/pull/50)
 
 ### 0.4.0 🌹
+
 March 30, 2020
 
 This release brings full support for Themes auto-updates.
@@ -129,6 +138,7 @@ It also changes the plugin structure to allow self deactivation when the feature
 Please note: the development repository was also migrated from @audrasjb’s personal GitHub account to WordPress.org official GitHub account.
 
 Other changes:
+
 - Change plugin structure to ensure it can self-deactivate when the feature is merged into Core - [#37](https://github.com/WordPress/wp-autoupdates/pull/37)
 - Handle both themes and plugins email notifications - [#36](https://github.com/WordPress/wp-autoupdates/pull/36)
 - i18n: Merge similar translation strings - [#35](https://github.com/WordPress/wp-autoupdates/pull/35)
@@ -136,7 +146,9 @@ Other changes:
 - Avoid duplicate Updating… dialog - [#32](https://github.com/WordPress/wp-autoupdates/pull/32)
 
 ### 0.3.0 🦉
+
 March 16, 2020
+
 - Add functions to handle plugins updates notification emails - [#54](https://github.com/audrasjb/wp-autoupdates/pull/54)
 - Remove update time text after manual update - [#43](https://github.com/audrasjb/wp-autoupdates/pull/43)
 - Ensure "Automatic Updates" column is not added if no content would be output in the column - [#57](https://github.com/audrasjb/wp-autoupdates/pull/57)
@@ -144,12 +156,16 @@ March 16, 2020
 - Prevent mis-match between count in Auto-updates Enabled view and the number of plugins displayed for that view by applying 'all_plugins' filter before computing that count. - [#59](https://github.com/audrasjb/wp-autoupdates/pull/59)
 
 ### 0.2.1 🐜
+
 March 11, 2020
+
 - Prevent "PHP Notice: Undefined index: plugin_status" when adding the autoupdates_column - [#47](https://github.com/audrasjb/wp-autoupdates/pull/47)
 - Add plugin_status query arg to the enable/disable links in the Automatic Updates column - [#48](https://github.com/audrasjb/wp-autoupdates/pull/48)
 
 ### 0.2 🐝
+
 March 6, 2020
+
 - Remove auto-updates column from mustuse and dropins screens - [#39](https://github.com/audrasjb/wp-autoupdates/pull/39)
 - Ensure the the enable/disable bulk actions appear in the dropdown and are handled in multisite - [#38](https://github.com/audrasjb/wp-autoupdates/pull/38)
 - Remove dashicon from "Enable" text in plugins auto-updates column - [#36](https://github.com/audrasjb/wp-autoupdates/pull/36)
@@ -161,28 +177,40 @@ March 6, 2020
 - Add auto-update-enabled and auto-update-disabled views on the plugins screen - [#18](https://github.com/audrasjb/wp-autoupdates/pull/18)
 
 ### Version 0.1.5 🐣
+
 February 26, 2020
+
 - Fix fatal error on PHP 7+
 - Fix legacy notice classes
 - Various tiny enhancements
 - Replace required PHP version
 
 ### Version 0.1.4 👻
+
 February 26, 2020
+
 - Fix PHP warnings.
 
 ### Version 0.1.3 ☀️
+
 February 25, 2020
+
 - Replace all "autoupdate" occurrences with "auto-update" which is now the official wording.
 
 ### Version 0.1.2
+
 February 23, 2020
+
 - Add time to next update in Plugins screen.
 
 ### Version 0.1.1
+
 February 19, 2020
+
 - Fixes few PHP notices/warnings.
 
 ### Version 0.1
+
 February 18, 2020
+
 - Initial release


### PR DESCRIPTION
This PR seeks to update the `js/wp-autoupdates.js` file per WordPress Coding Standards

This is performed via the `Add `@wordpress/scripts` package

To test this PR check out the branch and run `npm install`

The JS file has already been formatted with Prettier run `format:js` via c75714a

To run the _lint_ check using WP Coding Standards for CSS & JS run

For CSS Run `npm run lint:css`
For JS Run `npm run lint:js`

To run both, run `npm test` (or `npm t`)

The following ESLint warnings are displayed from the `lint:js` task:

```shell
/Users/netweb/Code/WordPress/wp-autoupdates/js/wp-autoupdates.js
    1:1   error  'jQuery' is not defined                             no-undef
    2:11  error  Identifier 'add_error_notice' is not in camel case  camelcase
   15:4   error  Unexpected var, use let or const instead            no-var
   17:4   error  Unexpected var, use let or const instead            no-var
   17:15  error  'wpAjax' is not defined                             no-undef
   18:4   error  Unexpected var, use let or const instead            no-var
   21:4   error  Unexpected var, use let or const instead            no-var
   26:6   error  'wp_autoupdates' is not defined                     no-undef
   30:5   error  'ajaxurl' is not defined                            no-undef
   37:15  error  'response' is defined but never used                no-unused-vars
   49:22  error  'wp_autoupdates' is not defined                     no-undef
   51:7   error  Unexpected var, use let or const instead            no-var
   59:22  error  'response' is defined but never used                no-unused-vars
   60:6   error  Unexpected var, use let or const instead            no-var
   62:7   error  'wp_autoupdates' is not defined                     no-undef
   64:21  error  'wp_autoupdates' is not defined                     no-undef
   67:24  error  'response' is defined but never used                no-unused-vars
   76:4   error  Unexpected var, use let or const instead            no-var
   78:4   error  Unexpected var, use let or const instead            no-var
   78:15  error  'wpAjax' is not defined                             no-undef
   79:4   error  Unexpected var, use let or const instead            no-var
   82:4   error  Unexpected var, use let or const instead            no-var
   90:7   error  'wp_autoupdates' is not defined                     no-undef
   94:5   error  'ajaxurl' is not defined                            no-undef
  101:15  error  'response' is defined but never used                no-unused-vars
  113:22  error  'wp_autoupdates' is not defined                     no-undef
  115:7   error  Unexpected var, use let or const instead            no-var
  123:22  error  'response' is defined but never used                no-unused-vars
  124:6   error  Unexpected var, use let or const instead            no-var
  126:7   error  'wp_autoupdates' is not defined                     no-undef
  128:21  error  'wp_autoupdates' is not defined                     no-undef
  131:24  error  'response' is defined but never used                no-unused-vars
  140:4   error  Unexpected var, use let or const instead            no-var
  142:4   error  Unexpected var, use let or const instead            no-var
  142:15  error  'wpAjax' is not defined                             no-undef
  143:4   error  Unexpected var, use let or const instead            no-var
  146:4   error  Unexpected var, use let or const instead            no-var
  151:6   error  'wp_autoupdates' is not defined                     no-undef
  155:5   error  'ajaxurl' is not defined                            no-undef
  162:15  error  'response' is defined but never used                no-unused-vars
  174:22  error  'wp_autoupdates' is not defined                     no-undef
  176:7   error  Unexpected var, use let or const instead            no-var
  184:22  error  'response' is defined but never used                no-unused-vars
  185:6   error  Unexpected var, use let or const instead            no-var
  187:7   error  'wp_autoupdates' is not defined                     no-undef
  189:21  error  'wp_autoupdates' is not defined                     no-undef
  192:24  error  'response' is defined but never used                no-unused-vars
  201:4   error  Unexpected var, use let or const instead            no-var
  203:4   error  Unexpected var, use let or const instead            no-var
  203:15  error  'wpAjax' is not defined                             no-undef
  204:4   error  Unexpected var, use let or const instead            no-var
  207:4   error  Unexpected var, use let or const instead            no-var
  215:7   error  'wp_autoupdates' is not defined                     no-undef
  219:5   error  'ajaxurl' is not defined                            no-undef
  226:15  error  'response' is defined but never used                no-unused-vars
  238:22  error  'wp_autoupdates' is not defined                     no-undef
  240:7   error  Unexpected var, use let or const instead            no-var
  248:22  error  'response' is defined but never used                no-unused-vars
  249:6   error  Unexpected var, use let or const instead            no-var
  251:7   error  'wp_autoupdates' is not defined                     no-undef
  253:21  error  'wp_autoupdates' is not defined                     no-undef
  256:24  error  'response' is defined but never used                no-unused-vars
  264:3   error  Unexpected var, use let or const instead            no-var
  266:3   error  Unexpected var, use let or const instead            no-var
  266:14  error  'wpAjax' is not defined                             no-undef
  267:3   error  Unexpected var, use let or const instead            no-var
  270:3   error  Unexpected var, use let or const instead            no-var
  275:5   error  'wp_autoupdates' is not defined                     no-undef
  279:4   error  'ajaxurl' is not defined                            no-undef
  286:14  error  'response' is defined but never used                no-unused-vars
  292:21  error  'wp_autoupdates' is not defined                     no-undef
  294:6   error  Unexpected var, use let or const instead            no-var
  302:21  error  'response' is defined but never used                no-unused-vars
  303:5   error  Unexpected var, use let or const instead            no-var
  305:6   error  'wp_autoupdates' is not defined                     no-undef
  307:20  error  'wp_autoupdates' is not defined                     no-undef
  310:23  error  'response' is defined but never used                no-unused-vars
  317:3   error  Unexpected var, use let or const instead            no-var
  319:3   error  Unexpected var, use let or const instead            no-var
  319:14  error  'wpAjax' is not defined                             no-undef
  320:3   error  Unexpected var, use let or const instead            no-var
  323:3   error  Unexpected var, use let or const instead            no-var
  330:6   error  'wp_autoupdates' is not defined                     no-undef
  334:4   error  'ajaxurl' is not defined                            no-undef
  341:14  error  'response' is defined but never used                no-unused-vars
  347:21  error  'wp_autoupdates' is not defined                     no-undef
  349:6   error  Unexpected var, use let or const instead            no-var
  357:21  error  'response' is defined but never used                no-unused-vars
  358:5   error  Unexpected var, use let or const instead            no-var
  360:6   error  'wp_autoupdates' is not defined                     no-undef
  362:20  error  'wp_autoupdates' is not defined                     no-undef
  365:23  error  'response' is defined but never used                no-unused-vars

✖ 92 problems (92 errors, 0 warnings)
  36 errors and 0 warnings potentially fixable with the `--fix` option.
```

Some of these are easy fixes using ESLint `--fix` option, others not so much

----

The background of the reason for this PR is that any new code being merged to WordPress should meet the WordPress Coding Standards

With some luck I'm hoping to get ESLint added in WP 5.5 to test that any new JS code introduced will meet the coding standards before being committed to the SVN repo

----

I'll leave this a draft PR for the time being, I don't think it should be merged as it will add more code to the repo that isn't going to be used when merged to core, feel free to push commits to this branch and then the final JS changes can be cherry-picked back to the `master` branch would be my suggestion