### PR TITLE
Remove constants from the feature plugin

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -169,14 +169,12 @@ add_action( 'wp_prepare_themes_for_js', 'wp_autoupdates_prepare_themes_for_js' )
  * @return bool True if plugins auto-update is enabled, false otherwise.
  */
 function wp_autoupdates_is_plugins_auto_update_enabled() {
-	$enabled = true;
-
 	/**
 	 * Filters whether plugins manual auto-update is enabled.
 	 *
 	 * @param bool $enabled True if plugins auto-update is enabled, false otherwise.
 	 */
-	return apply_filters( 'wp_plugins_auto_update_enabled', $enabled );
+	return apply_filters( 'wp_plugins_auto_update_enabled', true );
 }
 
 
@@ -186,14 +184,12 @@ function wp_autoupdates_is_plugins_auto_update_enabled() {
  * @return bool True if themes auto-update is enabled, false otherwise.
  */
 function wp_autoupdates_is_themes_auto_update_enabled() {
-	$enabled = true;
-
 	/**
 	 * Filters whether themes manual auto-update is enabled.
 	 *
 	 * @param bool $enabled True if themes auto-update is enabled, false otherwise.
 	 */
-	return apply_filters( 'wp_themes_auto_update_enabled', $enabled );
+	return apply_filters( 'wp_themes_auto_update_enabled', true );
 }
 
 
@@ -920,14 +916,12 @@ add_filter( 'debug_information', 'wp_autoupdates_debug_information' );
  * @return bool True if plugins notifications are enabled, false otherwise.
  */
 function wp_autoupdates_is_plugins_auto_update_email_enabled() {
-	$enabled = true;
-
 	/**
 	 * Filters whether plugins auto-update email notifications are enabled.
 	 *
 	 * @param bool $enabled True if plugins notifications are enabled, false otherwise.
 	 */
-	return apply_filters( 'send_plugins_auto_update_email', $enabled );
+	return apply_filters( 'send_plugins_auto_update_email', true );
 }
 
 
@@ -937,14 +931,12 @@ function wp_autoupdates_is_plugins_auto_update_email_enabled() {
  * @return bool True if themes notifications are enabled, false otherwise.
  */
 function wp_autoupdates_is_themes_auto_update_email_enabled() {
-	$enabled = true;
-
 	/**
 	 * Filters whether themes auto-update email notifications are enabled.
 	 *
 	 * @param bool $enabled True if themes notifications are enabled, false otherwise.
 	 */
-	return apply_filters( 'send_themes_auto_update_email', $enabled );
+	return apply_filters( 'send_themes_auto_update_email', true );
 }
 
 

--- a/functions.php
+++ b/functions.php
@@ -169,7 +169,7 @@ add_action( 'wp_prepare_themes_for_js', 'wp_autoupdates_prepare_themes_for_js' )
  * @return bool True if plugins auto-update is enabled, false otherwise.
  */
 function wp_autoupdates_is_plugins_auto_update_enabled() {
-	$enabled = ! defined( 'WP_DISABLE_PLUGINS_AUTO_UPDATE' ) || ! WP_DISABLE_PLUGINS_AUTO_UPDATE;
+	$enabled = true;
 
 	/**
 	 * Filters whether plugins manual auto-update is enabled.
@@ -186,7 +186,7 @@ function wp_autoupdates_is_plugins_auto_update_enabled() {
  * @return bool True if themes auto-update is enabled, false otherwise.
  */
 function wp_autoupdates_is_themes_auto_update_enabled() {
-	$enabled = ! defined( 'WP_DISABLE_THEMES_AUTO_UPDATE' ) || ! WP_DISABLE_THEMES_AUTO_UPDATE;
+	$enabled = true;
 
 	/**
 	 * Filters whether themes manual auto-update is enabled.
@@ -909,21 +909,6 @@ function wp_autoupdates_debug_information( $info ) {
 		}
 	}
 
-	// Populate constants informations.
-	$plugins_enabled = defined( 'WP_DISABLE_PLUGINS_AUTO_UPDATE' ) ? WP_DISABLE_PLUGINS_AUTO_UPDATE : __( 'Undefined', 'wp-autoupdates' );
-	$info['wp-constants']['fields']['WP_DISABLE_PLUGINS_AUTO_UPDATE'] = array(
-		'label' => 'WP_DISABLE_PLUGINS_AUTO_UPDATE',
-		'value' => $plugins_enabled,
-		'debug' => strtolower( $plugins_enabled ),
-	);
-
-	$themes_enabled = defined( 'WP_DISABLE_THEMES_AUTO_UPDATE' ) ? WP_DISABLE_THEMES_AUTO_UPDATE : __( 'Undefined', 'wp-autoupdates' );
-	$info['wp-constants']['fields']['WP_DISABLE_THEMES_AUTO_UPDATE'] = array(
-		'label' => 'WP_DISABLE_THEMES_AUTO_UPDATE',
-		'value' => $themes_enabled,
-		'debug' => strtolower( $themes_enabled ),
-	);
-
 	return $info;
 }
 add_filter( 'debug_information', 'wp_autoupdates_debug_information' );
@@ -935,7 +920,7 @@ add_filter( 'debug_information', 'wp_autoupdates_debug_information' );
  * @return bool True if plugins notifications are enabled, false otherwise.
  */
 function wp_autoupdates_is_plugins_auto_update_email_enabled() {
-	$enabled = ! defined( 'WP_DISABLE_PLUGINS_AUTO_UPDATE_EMAIL' ) || ! WP_DISABLE_PLUGINS_AUTO_UPDATE;
+	$enabled = true;
 
 	/**
 	 * Filters whether plugins auto-update email notifications are enabled.
@@ -952,7 +937,7 @@ function wp_autoupdates_is_plugins_auto_update_email_enabled() {
  * @return bool True if themes notifications are enabled, false otherwise.
  */
 function wp_autoupdates_is_themes_auto_update_email_enabled() {
-	$enabled = ! defined( 'WP_DISABLE_THEMES_AUTO_UPDATE_EMAIL' ) || ! WP_DISABLE_THEMES_AUTO_UPDATE;
+	$enabled = true;
 
 	/**
 	 * Filters whether themes auto-update email notifications are enabled.


### PR DESCRIPTION
Let's remove the previously introduced constants.

> After few discussions, it was also decided to remove the feature’s constants. Indeed, constants are used in WordPress core for specific cases:
> 
> - Very early use, before WP is loaded
> - For use mostly by hosting companies/low level settings
> - Mostly for things that are really “constant” (never change)

For reference, [see the following meeting recap](https://make.wordpress.org/core/2020/05/06/auto-updates-feature-meeting-summary-may-4-2020/).

Fixes #110 