### PR TITLE
Self-deactivate the plugin after the functionality has been merged to core

### DIFF
--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -26,8 +26,7 @@ define( 'WP_AUTO_UPDATES_VERSION', '0.7.0' );
 // Needs to run after the admin APIs have been loaded from wp-admin/includes/.
 function wp_autoupdates_self_deactivate() {
 	if (
-		function_exists( 'wp_is_plugins_auto_update_enabled' ) ||
-		function_exists( 'wp_autoupdates_get_update_message' ) ||
+		function_exists( 'wp_get_auto_update_message' ) ||
 		function_exists( 'wp_is_auto_update_enabled_for_type' )
 	) {
 		// Deactivate the plugin. This functionality has already been merged to core.

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -36,3 +36,18 @@ function wp_autoupdates_self_deactivate() {
 add_action( 'admin_init', 'wp_autoupdates_self_deactivate', 1 );
 
 include_once plugin_dir_path( __FILE__ ) . 'functions.php';
+
+
+/**
+ * Remove auto-updates data on uninstall.
+ */
+function wp_autoupdates_activate() {
+	register_uninstall_hook( __FILE__, 'wp_auto_update_uninstall' );
+}
+register_activation_hook( __FILE__, 'wp_autoupdates_activate' );
+
+function wp_auto_update_uninstall() {
+	delete_site_option( 'wp_auto_update_plugins' );
+	delete_site_option( 'wp_auto_update_themes' );
+}
+

--- a/wp-autoupdates.php
+++ b/wp-autoupdates.php
@@ -23,9 +23,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'WP_AUTO_UPDATES_VERSION', '0.7.0' );
 
-/**
- * Load only when needed.
- */
-if ( ! function_exists( 'wp_is_plugins_auto_update_enabled' ) ) {
-	include_once plugin_dir_path( __FILE__ ) . 'functions.php';
+// Needs to run after the admin APIs have been loaded from wp-admin/includes/.
+function wp_autoupdates_self_deactivate() {
+	if (
+		function_exists( 'wp_is_plugins_auto_update_enabled' ) ||
+		function_exists( 'wp_autoupdates_get_update_message' ) ||
+		function_exists( 'wp_is_auto_update_enabled_for_type' )
+	) {
+		// Deactivate the plugin. This functionality has already been merged to core.
+		deactivate_plugins( plugin_basename( __FILE__ ), false, is_network_admin() );
+	}
 }
+add_action( 'admin_init', 'wp_autoupdates_self_deactivate', 1 );
+
+include_once plugin_dir_path( __FILE__ ) . 'functions.php';


### PR DESCRIPTION
This will depend on where the functions are added in core.

If they are in `wp-admin/includes/*`, they are loaded after plugins are loaded, so the plugin cannot check if they exist before loading. In this case the function names from the plugin cannot be reused for core (results in fatal error). Adding the two or three functions to `wp-admin/includes/update.php` seems to make sense. The current code in this PR is for this case.

If they are in `wp-includes/*` the existing method would work. The check whether plugins and themes auto-updating is (globally) enabled may be in `wp-includes/update.php`.

In both of the above cases some updates to the code in `wp-autoupdates.php` would be needed.