### PR TITLE
Fix incorrect admin notice text when auto-updates are enabled for a plugin when JS is not enabled in the browser

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -363,7 +363,7 @@ function wp_autoupdates_handle_plugins_enable_disable() {
 
 		update_site_option( 'wp_auto_update_plugins', $auto_updates );
 
-		wp_redirect( self_admin_url( "plugins.php?disable-auto-update=true&plugin_status=$status&paged=$page&s=$s" ) );
+		wp_redirect( self_admin_url( "plugins.php?enable-auto-update=true&plugin_status=$status&paged=$page&s=$s" ) );
 		exit;
 	} elseif ( 'disable-auto-update' === $_GET['action'] ) {
 		if ( ! current_user_can( 'update_plugins' ) || ! wp_autoupdates_is_plugins_auto_update_enabled() ) {

--- a/js/wp-autoupdates.js
+++ b/js/wp-autoupdates.js
@@ -6,9 +6,9 @@
 	'use strict';
 
 	$( document ).ready( function() {
-		$( '.column-auto-updates, .theme-overlay' ).on(
+		$( document ).on(
 			'click',
-			'.toggle-auto-update',
+			'a.toggle-auto-update',
 			function( event ) {
 				var data, asset, type,
 					$anchor = $( this ),

--- a/js/wp-autoupdates.js
+++ b/js/wp-autoupdates.js
@@ -8,7 +8,7 @@
 	$( document ).ready( function() {
 		$( document ).on(
 			'click',
-			'a.toggle-auto-update',
+			'.column-auto-updates a.toggle-auto-update, .theme-overlay a.toggle-auto-update',
 			function( event ) {
 				var data, asset, type,
 					$anchor = $( this ),


### PR DESCRIPTION
This partially addresses #129.

Creating this as a draft PR, pending a solution to the other aspect of #129 (i.e., the `Enable/Disable` links not being bound to Ajax actions in the search results).