### PR TITLE
Prevent multiple simultaneous requests

### DIFF
--- a/js/wp-autoupdates.js
+++ b/js/wp-autoupdates.js
@@ -22,6 +22,13 @@
 
 				event.preventDefault();
 
+				// Prevent multiple simultaneous requests.
+				if ( $anchor.attr( 'data-doing-ajax' ) === 'yes' ) {
+					return;
+				}
+
+				$anchor.attr( 'data-doing-ajax', 'yes' );
+
 				switch ( pagenow ) {
 					case 'plugins':
 					case 'plugins-network':
@@ -165,6 +172,7 @@
 					} )
 					.always( function() {
 						$anchor
+							.removeAttr( 'data-doing-ajax' )
 							.find( '.dashicons-update' )
 							.addClass( 'hidden' );
 					} );


### PR DESCRIPTION
Prevents multiple simultaneous requests for the same plugin/theme if the user clicks on the link before the previous request is complete.

To test:
- Make sure the network is not extremely fast (like when testing on local install).
Maybe add `sleep( 5 );` to wp-config.php if needed. 
- Open the browser tools, network tab, then click on the enable/disable link multiple times.

There should be only one request to admin-ajax.php at a time.