### PR TITLE
Remove unnecessary translatable strings

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1014,8 +1014,7 @@ function wp_autoupdates_send_email_notification( $type, $successful_updates, $fa
 		$body[] = __( 'The following plugins failed to update:' );
 		// List failed updates.
 		foreach ( $failed_updates['plugin'] as $item ) {
-			/* translators: %s: Name of the related plugin. */
-			$body[] = ' ' . sprintf( __( '- %s', 'wp-autoupdates' ), $item->name );
+			$body[] = '- ' . $item->name;
 		}
 		$body[] = "\n";
 	}
@@ -1024,8 +1023,7 @@ function wp_autoupdates_send_email_notification( $type, $successful_updates, $fa
 		$body[] = __( 'The following themes failed to update:' );
 		// List failed updates.
 		foreach ( $failed_updates['theme'] as $item ) {
-			/* translators: %s: Name of the related plugin. */
-			$body[] = ' ' . sprintf( __( '- %s', 'wp-autoupdates' ), $item->name );
+			$body[] = '- ' . $item->name;
 		}
 		$body[] = "\n";
 	}
@@ -1035,7 +1033,7 @@ function wp_autoupdates_send_email_notification( $type, $successful_updates, $fa
 		// List successful updates.
 		foreach ( $successful_updates['plugin'] as $plugin ) {
 			/* translators: %s: Name of the related plugin. */
-			$body[] = ' ' . sprintf( __( '- %s', 'wp-autoupdates' ), $plugin->name );
+			$body[] = '- ' . $plugin->name;
 		}
 		$body[] = "\n";
 	}
@@ -1045,7 +1043,7 @@ function wp_autoupdates_send_email_notification( $type, $successful_updates, $fa
 		// List successful updates.
 		foreach ( $successful_updates['theme'] as $plugin ) {
 			/* translators: %s: Name of the related plugin. */
-			$body[] = ' ' . sprintf( __( '- %s', 'wp-autoupdates' ), $plugin->name );
+			$body[] = '- ' . $plugin->name );
 		}
 		$body[] = "\n";
 	}

--- a/functions.php
+++ b/functions.php
@@ -1014,7 +1014,7 @@ function wp_autoupdates_send_email_notification( $type, $successful_updates, $fa
 		$body[] = __( 'The following plugins failed to update:' );
 		// List failed updates.
 		foreach ( $failed_updates['plugin'] as $item ) {
-			$body[] = '- ' . $item->name;
+			$body[] = "- {$item->name}";
 		}
 		$body[] = "\n";
 	}
@@ -1023,7 +1023,7 @@ function wp_autoupdates_send_email_notification( $type, $successful_updates, $fa
 		$body[] = __( 'The following themes failed to update:' );
 		// List failed updates.
 		foreach ( $failed_updates['theme'] as $item ) {
-			$body[] = '- ' . $item->name;
+			$body[] = "- {$item->name}";
 		}
 		$body[] = "\n";
 	}
@@ -1031,9 +1031,8 @@ function wp_autoupdates_send_email_notification( $type, $successful_updates, $fa
 	if ( in_array( $type, array( 'success', 'mixed' ), true ) && ! empty( $successful_updates['plugin'] ) ) {
 		$body[] = __( 'The following plugins were successfully updated:' );
 		// List successful updates.
-		foreach ( $successful_updates['plugin'] as $plugin ) {
-			/* translators: %s: Name of the related plugin. */
-			$body[] = '- ' . $plugin->name;
+		foreach ( $successful_updates['plugin'] as $item ) {
+			$body[] = "- {$item->name}";
 		}
 		$body[] = "\n";
 	}
@@ -1041,9 +1040,8 @@ function wp_autoupdates_send_email_notification( $type, $successful_updates, $fa
 	if ( in_array( $type, array( 'success', 'mixed' ), true ) && ! empty( $successful_updates['theme'] ) ) {
 		$body[] = __( 'The following themes were successfully updated:' );
 		// List successful updates.
-		foreach ( $successful_updates['theme'] as $plugin ) {
-			/* translators: %s: Name of the related plugin. */
-			$body[] = '- ' . $plugin->name );
+		foreach ( $successful_updates['theme'] as $item ) {
+			$body[] = "- {$item->name}";
 		}
 		$body[] = "\n";
 	}


### PR DESCRIPTION
As per @ocean90’s feedback, let's remove some unnecessary translatable strings.
For reference: https://github.com/WordPress/wordpress-develop/pull/279#discussion_r426837240